### PR TITLE
make PromLoad work for linuxRT

### DIFF
--- a/software/PromLoader/EvrCardG2Prom.h
+++ b/software/PromLoader/EvrCardG2Prom.h
@@ -38,7 +38,7 @@ class EvrCardG2Prom {
    public:
 
       //! Constructor
-      EvrCardG2Prom (void volatile *mapStart, string pathToFile );
+      EvrCardG2Prom (volatile void *mapStart, string pathToFile );
 
       //! Deconstructor
       ~EvrCardG2Prom ( );
@@ -70,13 +70,13 @@ class EvrCardG2Prom {
       string   filePath;
       bool     promType_;
       uint32_t promSize_;
-      void volatile *mapVersion;
-      void volatile *mapPromType;
-      void volatile *mapBuild;
-      void volatile *mapData;
-      void volatile *mapAddress;
-      void volatile *mapRead;
-      void volatile *mapTest;
+      volatile void  *mapVersion;
+      volatile void  *mapPromType;
+      volatile void  *mapBuild;
+      volatile void  *mapData;
+      volatile void  *mapAddress;
+      volatile void  *mapRead;
+      volatile void  *mapTest;
 
       //! Erase Command
       void eraseCommand(uint32_t address);


### PR DESCRIPTION
### Description
- [make PromLoad work in linuxRT, put volatile explicitly for force type casting in wrotetoFlash() method](https://github.com/slaclab/evr-card-g2/pull/12/commits/fee32d64c8189f8f9af6cb74df7ad26f4501ca0a)