### PR TITLE
fix potential issue using uninitialized variable

### DIFF
--- a/software/PromLoader/McsRead.cpp
+++ b/software/PromLoader/McsRead.cpp
@@ -111,7 +111,7 @@ uint32_t McsRead::addrSize ( ) {
 
 // Get next memory data and address index
 int32_t McsRead::read (McsReadData *mem) {
-   int32_t status;
+   int32_t status = 0;
 
    //check if we need to read the next line
    if(promPntr==16) {


### PR DESCRIPTION
Fix to avoid potential issues caused by using an uninitialized variable.